### PR TITLE
Linkify URLs in event view and table

### DIFF
--- a/tpl/events_table.tpl
+++ b/tpl/events_table.tpl
@@ -40,6 +40,8 @@
                 % for val in v:
                     <span class="label">{{val}}</span>
                 % end
+            % elif k.endswith('_url'):
+                <a href="{{v}}">{{v}}</a>
             % else:
                 {{v}}
             %end

--- a/tpl/events_view.tpl
+++ b/tpl/events_view.tpl
@@ -40,6 +40,8 @@
                 % for val in v:
                     <span class="label">{{val}}</span>
                 % end
+            % elif k.endswith('_url'):
+                <a href="{{v}}">{{v}}</a>
             % else:
                 {{v}}
             %end


### PR DESCRIPTION
Feel free to axe this PR, but we've found it handy for ourselves, so I figured I'd pass it along. This basically just turns the value of any field whose name ends in "_url" into a link on the `/events/table` and `/events/view/<id>` pages.