### PR TITLE
Allow ES index to be an alias

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -143,6 +143,8 @@ class Backend():
             import re
             if 'IndexAlreadyExistsException' in e.result['error']:
                 pass
+            elif 'already exists as alias' in e.result['error']:
+                pass
             else:
                 raise
         except requests.exceptions.ConnectionError as e:


### PR DESCRIPTION
When Anthracite attempts to create the ES index (and passes if it already exists), it bombs out when the index is an alias. We are hitting an index which actually is an alias, but it always points to the index with the current mapping.
